### PR TITLE
Make colours readable on real Pebble

### DIFF
--- a/src/colors.h
+++ b/src/colors.h
@@ -1,0 +1,7 @@
+#include <pebble.h>
+
+#define COLOR_BG GColorVeryLightBlue
+#define COLOR_TEXT GColorRichBrilliantLavender
+#define COLOR_HIGHLIGHT GColorRichBrilliantLavender
+#define COLOR_HIGHLIGHT_TEXT GColorWhite
+#define WRONG_ANSWER_COLOR GColorElectricUltramarine

--- a/src/colors.h
+++ b/src/colors.h
@@ -1,7 +1,7 @@
 #include <pebble.h>
 
-#define COLOR_BG GColorVeryLightBlue
-#define COLOR_TEXT GColorRichBrilliantLavender
-#define COLOR_HIGHLIGHT GColorRichBrilliantLavender
+#define COLOR_BG GColorBlue
+#define COLOR_TEXT GColorWhite
+#define COLOR_HIGHLIGHT GColorPurple
 #define COLOR_HIGHLIGHT_TEXT GColorWhite
-#define WRONG_ANSWER_COLOR GColorElectricUltramarine
+#define WRONG_ANSWER_COLOR GColorDarkCandyAppleRed

--- a/src/kana_app_learn.c
+++ b/src/kana_app_learn.c
@@ -3,6 +3,7 @@
 #include "kana_app_glyphs.h"
 #include "kana_app_resources.h"
 #include "kana_app_simple_menu_color.h"
+#include "colors.h"
 
 #ifdef PBL_COLOR
 extern GColor kana_app_bitmap_pallete[2];
@@ -40,8 +41,8 @@ static void top_list_load(Window* window) {
   #ifdef PBL_COLOR
   kana_app_simple_menu_set_color(
     ui.menu,
-    GColorVeryLightBlue, GColorRichBrilliantLavender,
-    GColorRichBrilliantLavender, GColorWhite);
+    COLOR_BG, COLOR_TEXT,
+    COLOR_HIGHLIGHT, COLOR_HIGHLIGHT_TEXT);
   #endif
 }
 
@@ -76,8 +77,8 @@ static void details_list_load(Window* window) {
   #ifdef PBL_COLOR
     kana_app_simple_menu_set_color(
       details_ui.menu,
-      GColorVeryLightBlue, GColorRichBrilliantLavender,
-      GColorRichBrilliantLavender, GColorWhite);
+      COLOR_BG, COLOR_TEXT,
+      COLOR_HIGHLIGHT, COLOR_HIGHLIGHT_TEXT);
   #endif
 }
 

--- a/src/kana_app_main_menu.c
+++ b/src/kana_app_main_menu.c
@@ -3,6 +3,7 @@
 #include "kana_app_settings.h"
 #include "kana_app_learn.h"
 #include "kana_app_quiz.h"
+#include "colors.h"
 
 // - Start Quiz
 // - Learn Hiragana
@@ -91,8 +92,8 @@ static void load(Window* window) {
         });
 
     #ifdef PBL_COLOR
-        menu_layer_set_normal_colors(menu, GColorVeryLightBlue, GColorRichBrilliantLavender);
-        menu_layer_set_highlight_colors(menu, GColorRichBrilliantLavender, GColorWhite);    
+        menu_layer_set_normal_colors(menu, COLOR_BG, COLOR_TEXT);
+        menu_layer_set_highlight_colors(menu, COLOR_HIGHLIGHT, COLOR_HIGHLIGHT_TEXT);    
     #endif
 
     menu_layer_set_click_config_onto_window(menu, window);

--- a/src/kana_app_quiz.c
+++ b/src/kana_app_quiz.c
@@ -4,12 +4,11 @@
 #include "kana_app_resources.h"
 #include "kana_app_glyphs.h"
 #include "kana_app_settings.h"
+#include "colors.h"
 
 #ifdef PBL_COLOR
-  #define BG_COLOR GColorVeryLightBlue
-  #define FG_COLOR GColorRichBrilliantLavender
-  #define SEC_FG_COLOR GColorRichBrilliantLavender
-  #define WRONG_ANSWER_COLOR GColorElectricUltramarine
+  #define FG_COLOR COLOR_TEXT
+  #define SEC_FG_COLOR COLOR_TEXT
 #endif
 #define GLYPH_DIMENSIONS 120
 
@@ -65,7 +64,7 @@ static struct Ui {
 
     GRect rect_bottom = bounds;
 
-    graphics_context_set_fill_color(ctx, BG_COLOR);
+    graphics_context_set_fill_color(ctx, COLOR_BG);
     graphics_fill_rect(ctx, rect_bottom, 0, GCornerNone);
   }
 #endif
@@ -371,10 +370,10 @@ void kana_app_quiz_init() {
 
   #ifdef PBL_COLOR
   kana_app_bitmap_pallete[0] = FG_COLOR;
-  kana_app_bitmap_pallete[1] = BG_COLOR;
+  kana_app_bitmap_pallete[1] = COLOR_BG;
 
   kana_app_bitmap_error_pallete[0] = WRONG_ANSWER_COLOR;
-  kana_app_bitmap_error_pallete[1] = BG_COLOR;
+  kana_app_bitmap_error_pallete[1] = COLOR_BG;
   #endif
 
   window_set_window_handlers(ui.window,

--- a/src/kana_app_resources.c
+++ b/src/kana_app_resources.c
@@ -48,7 +48,7 @@ char *kana_app_rows_names[ALPHABET_ROW_NUM] =
 char *kana_app_romaji[ALPHABET_ROW_NUM][5] = 
   {{"A",  "I",   "U",   "E",  "O"},
    {"KA", "KI",  "KU",  "KE", "KO"},
-   {"SA", "SI",  "SU",  "SE", "SO"},
+   {"SA", "SHI",  "SU",  "SE", "SO"},
    {"TA", "CHI", "TSU", "TE", "TO"},   
    {"NA", "NI",  "NU",  "NE", "NO"},   
    {"HA", "HI",  "FU",  "HE", "HO"},

--- a/src/kana_app_settings.c
+++ b/src/kana_app_settings.c
@@ -3,6 +3,7 @@
 #include "kana_app_resources.h"
 #include "kana_app_simple_menu_color.h"
 #include "kana_app_simple_menu_color.h"
+#include "colors.h"
 
 static SimpleColorMenuLayer *simpleMenu;
 
@@ -58,8 +59,8 @@ void kana_app_settings_init() {
     #ifdef PBL_COLOR
         kana_app_simple_menu_set_color(
             simpleMenu,
-            GColorVeryLightBlue, GColorRichBrilliantLavender,
-            GColorRichBrilliantLavender, GColorWhite);
+            COLOR_BG, COLOR_TEXT,
+            COLOR_HIGHLIGHT, COLOR_HIGHLIGHT_TEXT);
     #endif
 }
 


### PR DESCRIPTION
Hello. Nice app. It certainly looks good in the Basalt emulator. However, on my Pebble Time the menus are completely unreadable both with and without the backlight because there is very low contrast. If you look at https://developer.getpebble.com/more/color-picker you will see Uncorrected and Sunlight versions of the colours. I've tried to match the new colours to the emulator versions as closely as possible. Not sure what to do about the Fuji image.
Hope you don't mind this PR. If you want to tweak the colours, you can merge my previous commit instead where I moved the colours out into a header file.
